### PR TITLE
Seed Database with admin user by default for development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "php": "^7.3|^8.0",
         "arcanedev/log-viewer": "^8.1",
         "badaso/core": "^2.4.7",
+        "bensampo/laravel-enum": "^4.2",
         "darkaonline/l5-swagger": "^8.0",
         "doctrine/dbal": "^2.12",
         "fideloper/proxy": "^4.4",
@@ -61,7 +62,8 @@
             "Uasoft\\Badaso\\": "package/badaso/core/src/",
             "Uasoft\\Badaso\\Theme\\LMSTheme\\": "package/badaso/badaso-lms-theme/src/",
             "Uasoft\\Badaso\\Module\\LMSModule\\": "package/badaso/lms-module/src/",
-            "Uasoft\\Badaso\\Module\\LMSModule\\Database\\Factories\\": "package/badaso/lms-module/src/Factories/"
+            "Uasoft\\Badaso\\Module\\LMSModule\\Factories\\": "package/badaso/lms-module/src/Factories/",
+            "Uasoft\\Badaso\\Module\\LMSModule\\Seeders\\": "package/badaso/lms-module/src/Seeders/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
             "Database\\Seeders\\": "database/seeders/",
             "Uasoft\\Badaso\\": "package/badaso/core/src/",
             "Uasoft\\Badaso\\Theme\\LMSTheme\\": "package/badaso/badaso-lms-theme/src/",
-            "Uasoft\\Badaso\\Module\\LMSModule\\": "package/badaso/lms-module/src/"
+            "Uasoft\\Badaso\\Module\\LMSModule\\": "package/badaso/lms-module/src/",
+            "Uasoft\\Badaso\\Module\\LMSModule\\Database\\Factories\\": "package/badaso/lms-module/src/Factories/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "arcanedev/log-viewer": "^8.1",
-        "badaso/core": "^2.4",
+        "badaso/core": "^2.4.7",
         "darkaonline/l5-swagger": "^8.0",
         "doctrine/dbal": "^2.12",
         "fideloper/proxy": "^4.4",

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,7 +1,7 @@
 <?php
 return [
     'defaults' => [
-        'guard' => 'web',
+        'guard' => 'badaso_guard',
         'passwords' => 'users',
     ],
     'guards' => [
@@ -14,9 +14,17 @@ return [
             'provider' => 'users',
             'hash' => false,
         ],
+        'badaso_guard' => [
+            'driver' => 'jwt',
+            'provider' => 'badaso_users',
+        ],
     ],
     'providers' => [
         'users' => [
+            'driver' => 'eloquent',
+            'model' => 'Uasoft\\Badaso\\Models\\User',
+        ],
+        'badaso_users' => [
             'driver' => 'eloquent',
             'model' => 'Uasoft\\Badaso\\Models\\User',
         ],

--- a/database/seeders/Badaso/BadasoSeeder.php
+++ b/database/seeders/Badaso/BadasoSeeder.php
@@ -22,6 +22,8 @@ class BadasoSeeder extends Seeder
         $this->call(FixedMenuItemSeeder::class);
         $this->call(ConfigurationsSeeder::class);
 
+        // TODO: Remove this line before deploying to production
+        // to avoid the creation of admin admin user
         $this->call(BadasoManualGenerateSeeder::class);
         $this->call(BadasoLMSModuleSeeder::class);
     }

--- a/database/seeders/Badaso/BadasoSeeder.php
+++ b/database/seeders/Badaso/BadasoSeeder.php
@@ -2,7 +2,9 @@
 
 namespace Database\Seeders\Badaso;
 
+use Database\Seeders\Badaso\ManualGenerate\BadasoManualGenerateSeeder;
 use Illuminate\Database\Seeder;
+use Uasoft\Badaso\Module\LMSModule\Seeders\BadasoLMSModuleSeeder;
 
 class BadasoSeeder extends Seeder
 {
@@ -19,5 +21,8 @@ class BadasoSeeder extends Seeder
         $this->call(MenusSeeder::class);
         $this->call(FixedMenuItemSeeder::class);
         $this->call(ConfigurationsSeeder::class);
+
+        $this->call(BadasoManualGenerateSeeder::class);
+        $this->call(BadasoLMSModuleSeeder::class);
     }
 }

--- a/database/seeders/Badaso/ManualGenerate/BadasoManualGenerateSeeder.php
+++ b/database/seeders/Badaso/ManualGenerate/BadasoManualGenerateSeeder.php
@@ -13,5 +13,6 @@ class BadasoManualGenerateSeeder extends Seeder
 
     public function run()
     {
+        $this->seed(BadasoUsersTableSeeder::class);
     }
 }

--- a/database/seeders/Badaso/ManualGenerate/BadasoUsersTableSeeder.php
+++ b/database/seeders/Badaso/ManualGenerate/BadasoUsersTableSeeder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Database\Seeders\Badaso\ManualGenerate;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Hash;
+use Uasoft\Badaso\Facades\Badaso;
+use Uasoft\Badaso\Models\Role;
+use Uasoft\Badaso\Models\User;
+use Uasoft\Badaso\Models\UserRole;
+
+class BadasoUsersTableSeeder extends Seeder
+{
+	/**
+	* Auto generated seed file
+	*
+	* @return void
+	*
+	* @throws Exception
+	*/
+	public function run()
+	{
+		\DB::beginTransaction();
+		try {
+			$user = User::create([
+				'name' => 'admin',
+				'username' => 'admin',
+				'email' => 'admin@admin.com',
+				'email_verified_at' => date('Y-m-d H:i:s'),
+				'password' => Hash::make('admin'),
+			]);
+
+			$role = Role::where('name', 'administrator')->first();
+
+			if (is_null($role)) {
+				$role = new Role();
+				$role->name = 'administrator';
+				$role->display_name = 'Administrator';
+				$role->save();
+			}
+
+			UserRole::create([
+				'user_id' => $user->id,
+				'role_id' => $role->id,
+			]);
+
+			\DB::commit();
+		} catch(Exception $e) {
+			\DB::rollBack();
+
+			throw new Exception('Exception occur ' . $e);
+		}
+	}
+}


### PR DESCRIPTION
It's just so tedious to manually create an admin user everytime we restart the db, so why don't we just seed it by default in this development mode. Just need to remember to remove it before deploying to production